### PR TITLE
Stop using obsolete inheritance-based PeriodicBatchingSink API

### DIFF
--- a/src/Serilog.Sinks.Graylog.Batching/BatchingGraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog.Batching/BatchingGraylogSinkOptions.cs
@@ -1,4 +1,5 @@
 using Serilog.Sinks.Graylog.Core;
+using Serilog.Sinks.PeriodicBatching;
 using System;
 
 namespace Serilog.Sinks.Graylog.Batching
@@ -7,15 +8,14 @@ namespace Serilog.Sinks.Graylog.Batching
     {
         public BatchingGraylogSinkOptions()
         {
-            BatchSizeLimit = 10;
-            Period = TimeSpan.FromSeconds(1);
-            QueueLimit = 10;
+            PeriodicOptions = new PeriodicBatchingSinkOptions()
+            {
+                BatchSizeLimit = 10,
+                Period = TimeSpan.FromSeconds(1),
+                QueueLimit = 10,
+            };
         }
 
-        public int BatchSizeLimit { get; set; }
-
-        public TimeSpan Period { get; set; }
-
-        public int QueueLimit { get; set; }
+        public PeriodicBatchingSinkOptions PeriodicOptions { get; set; }
     }
 }

--- a/src/Serilog.Sinks.Graylog.Batching/LoggerConfigurationGrayLogExtensions.cs
+++ b/src/Serilog.Sinks.Graylog.Batching/LoggerConfigurationGrayLogExtensions.cs
@@ -4,6 +4,7 @@ using Serilog.Events;
 using Serilog.Sinks.Graylog.Core;
 using Serilog.Sinks.Graylog.Core.Helpers;
 using Serilog.Sinks.Graylog.Core.Transport;
+using Serilog.Sinks.PeriodicBatching;
 using System;
 
 namespace Serilog.Sinks.Graylog.Batching
@@ -19,8 +20,11 @@ namespace Serilog.Sinks.Graylog.Batching
         public static LoggerConfiguration Graylog(this LoggerSinkConfiguration loggerSinkConfiguration,
                                                   BatchingGraylogSinkOptions options)
         {
-            var sink = (ILogEventSink)new PeriodicBatchingGraylogSink(options);
-            return loggerSinkConfiguration.Sink(sink, options.MinimumLogEventLevel);
+            var sink = new PeriodicBatchingGraylogSink(options);
+
+            var batchingSink = new PeriodicBatchingSink(sink, options.PeriodicOptions);
+
+            return loggerSinkConfiguration.Sink(batchingSink, options.MinimumLogEventLevel);
         }
 
         /// <summary>
@@ -75,14 +79,16 @@ namespace Serilog.Sinks.Graylog.Batching
                 ShortMessageMaxLength = shortMessageMaxLength,
                 StackTraceDepth = stackTraceDepth,
                 Facility = facility,
-                BatchSizeLimit = batchSizeLimit,
-                Period = period,
-                QueueLimit = queueLimit,
+                PeriodicOptions = new PeriodicBatchingSinkOptions()
+                {
+                    BatchSizeLimit = batchSizeLimit,
+                    Period = period,
+                    QueueLimit = queueLimit,
+                },
                 MaxMessageSizeInUdp = maxMessageSizeInUdp,
                 IncludeMessageTemplate = includeMessageTemplate,
                 MessageTemplateFieldName = messageTemplateFieldName
             };
-            options.TransportType = TransportType.Udp;
             return loggerSinkConfiguration.Graylog(options);
         }
     }


### PR DESCRIPTION
The `PeriodicBatchingSink` library had deprecated passing the subclass of `PeriodicBatchingSink` to `loggerSinkConfiguration.Sink()`, and then removed support for the obsolete approach. Since the Graylog batching sink was not updated, attempting to initialize it resulted in https://github.com/serilog-contrib/serilog-sinks-graylog/issues/97.

While `PeriodicBatchingSink` reintroduced the removed APIs to maintain backwards compatibility in version 3.1.0, the Graylog batching sink references version 2.3.1. An easier solution would have been to simply update the `PeriodicBatchingSink` dependency to 3.1.0 but then we would still be depending on obsolete code which has already been removed once. 

This updates the batching sink to use the correct approach instead.