### PR TITLE
Removing `async` from `Emit` method because ASP.NET does not like it

### DIFF
--- a/src/Serilog.Sinks.Graylog/GraylogSink.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSink.cs
@@ -26,12 +26,11 @@ namespace Serilog.Sinks.Graylog
             _converter = new Lazy<IGelfConverter>(() => sinkComponentsBuilder.MakeGelfConverter());
         }
 
-        //should work
-        public async void Emit(LogEvent logEvent)
+        public void Emit(LogEvent logEvent)
         {
             try
             {
-                await EmitAsync(logEvent).ConfigureAwait(false);
+                EmitAsync(logEvent).ConfigureAwait(false);
             } catch (Exception exc)
             {
                 SelfLog.WriteLine("Oops something going wrong {0}", exc);


### PR DESCRIPTION
The full exception message is:

_An asynchronous operation cannot be started at this time. Asynchronous operations may only be started within an asynchronous handler or module or during certain events in the Page lifecycle. If this exception occurred while executing a Page, ensure that the Page is marked <%@ Page Async="true" %>. This exception may also indicate an attempt to call an **"async void" method, which is generally unsupported within ASP.NET request processing**. Instead, the asynchronous method should return a Task, and the caller should await it._


The `Emit` method is called inside Serilog via an interface and I do not see a reason why `async` is needed. I am removing it. 
